### PR TITLE
Require stable version of budo

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/mattdesl"
   },
   "dependencies": {
-    "budo": "^5.0.0-beta3",
+    "budo": "^5.0.0",
     "concat-stream": "^1.5.0",
     "filed": "^0.1.0",
     "less": "^2.5.1",


### PR DESCRIPTION
This moves from the beta of 5.x to the stable version of 5.x. Everything still looks good.
