### PR TITLE
README: "last 2 browsers" -> "last 2 versions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Examples:
 ```sh
 budo-less foo.js --less=foo/main.less | garnish
 budo-less foo.js --css=static/main.css --less=src/main.less
-budo-less foo.js --less=main.css --autoprefix="last 2 browsers"
+budo-less foo.js --less=main.css --autoprefix="last 2 versions"
 ```
 
 ## API Example


### PR DESCRIPTION
The former isn't a valid directive for autoprefixer and triggers `Unknown browser query`last 2 browsers`` if used verbatim from the README 😄
